### PR TITLE
Closed areas

### DIFF
--- a/hangry_games/migrations/2024-08-29-192234_add_closed_areas/down.sql
+++ b/hangry_games/migrations/2024-08-29-192234_add_closed_areas/down.sql
@@ -1,0 +1,2 @@
+-- Remove the closed_areas field
+ALTER TABLE game DROP COLUMN closed_areas;

--- a/hangry_games/migrations/2024-08-29-192234_add_closed_areas/up.sql
+++ b/hangry_games/migrations/2024-08-29-192234_add_closed_areas/up.sql
@@ -1,0 +1,2 @@
+-- Hold list of closed areas
+ALTER TABLE game ADD COLUMN closed_areas integer[];

--- a/hangry_games/src/models/tribute.rs
+++ b/hangry_games/src/models/tribute.rs
@@ -226,7 +226,7 @@ impl Tribute {
         // Rest the tribute
         self.health = std::cmp::min(self.health + 50, 100);
         self.sanity = std::cmp::min(self.sanity + 50, 100);
-        self.movement = std::cmp::min(self.movement + 50, 100);
+        self.movement = std::cmp::min(self.movement + 25, 100);
 
         diesel::update(tribute::table.find(self.id))
             .set((
@@ -241,6 +241,11 @@ impl Tribute {
 
     // TODO: Extract from impl
     fn move_tribute(&self, connection: &mut PgConnection, mut tribute: crate::tributes::actors::Tribute) {
+        if tribute.movement < 25 {
+            println!("{} is too tired to move", tribute.name);
+            return;
+        }
+
         let current_area = tribute.area.unwrap();
         let random_neighbor = current_area.neighbors().choose(&mut rand::thread_rng()).unwrap().clone();
 

--- a/hangry_games/src/schema.rs
+++ b/hangry_games/src/schema.rs
@@ -23,6 +23,7 @@ diesel::table! {
         name -> Text,
         created_at -> Timestamp,
         day -> Nullable<Int4>,
+        closed_areas -> Nullable<Array<Nullable<Int4>>>,
     }
 }
 

--- a/hangry_games/src/tributes/actors.rs
+++ b/hangry_games/src/tributes/actors.rs
@@ -62,6 +62,11 @@ impl TributeBrain {
             };
         }
 
+        if nearby_tributes.len() > 5 {
+            // too many enemies nearby, run away
+            return TributeAction::Move;
+        }
+
         // no enemies nearby
         match tribute.health {
             // health is low, rest


### PR DESCRIPTION
Allows you to close areas via the command line. Tributes will flee closed areas on their next turn and will not select those areas to go into