### PR TITLE
suggest-move-to-area

### DIFF
--- a/hangry_games/migrations/2024-09-15-230142_add-target-field/down.sql
+++ b/hangry_games/migrations/2024-09-15-230142_add-target-field/down.sql
@@ -1,0 +1,2 @@
+-- Remove the `target` field from the `tribute_action` table
+ALTER TABLE tribute_action DROP COLUMN target;

--- a/hangry_games/migrations/2024-09-15-230142_add-target-field/up.sql
+++ b/hangry_games/migrations/2024-09-15-230142_add-target-field/up.sql
@@ -1,0 +1,3 @@
+-- Add `target` field to `tribute_action` table to record
+-- the target of the tribute action, like an area or item.
+ALTER TABLE tribute_action ADD COLUMN target TEXT;

--- a/hangry_games/src/areas.rs
+++ b/hangry_games/src/areas.rs
@@ -83,6 +83,12 @@ impl From<AreaModel> for Area {
     }
 }
 
+impl From<String> for Area {
+    fn from(s: String) -> Self {
+        Self::from_str(s.as_str()).unwrap_or(Area::Cornucopia)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Area;

--- a/hangry_games/src/areas.rs
+++ b/hangry_games/src/areas.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use rand::Rng;
 
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub enum Area {
     #[default]
     Cornucopia,

--- a/hangry_games/src/cli.rs
+++ b/hangry_games/src/cli.rs
@@ -178,7 +178,21 @@ pub fn parse() {
             }
             println!("Statuses");
             for tribute in living_tributes {
-                println!("{} is {}, {}/100, {}({:?})", tribute.name, tribute.status, tribute.health, tribute.actions().last().unwrap().name, tribute.actions().last().unwrap());
+                let actions = tribute.actions();
+                let last_actions = actions.last_chunk::<2>();
+                let last_action = last_actions.unwrap().last().unwrap();
+                let next_to_last_action = last_actions.unwrap().first().unwrap();
+
+                println!("{} is {}, {}/100, {}/100, {}({:?}) -> {}({:?})",
+                    tribute.name,
+                    tribute.status,
+                    tribute.health,
+                    tribute.sanity,
+                    next_to_last_action.name,
+                    next_to_last_action,
+                    last_action.name,
+                    last_action,
+                );
             }
         }
         Commands::QuickStart => {

--- a/hangry_games/src/cli.rs
+++ b/hangry_games/src/cli.rs
@@ -178,19 +178,17 @@ pub fn parse() {
             }
             println!("Statuses");
             for tribute in living_tributes {
-                let actions = tribute.actions();
+                let actions = tribute.tribute_actions();
                 let last_actions = actions.last_chunk::<2>();
                 let last_action = last_actions.unwrap().last().unwrap();
                 let next_to_last_action = last_actions.unwrap().first().unwrap();
 
-                println!("{} is {}, {}/100, {}/100, {}({:?}) -> {}({:?})",
+                println!("{} is {}, {}/100, {}/100, ({:?}) -> ({:?})",
                     tribute.name,
                     tribute.status,
                     tribute.health,
                     tribute.sanity,
-                    next_to_last_action.name,
                     next_to_last_action,
-                    last_action.name,
                     last_action,
                 );
             }

--- a/hangry_games/src/cli.rs
+++ b/hangry_games/src/cli.rs
@@ -178,7 +178,7 @@ pub fn parse() {
             }
             println!("Statuses");
             for tribute in living_tributes {
-                println!("{} is {}, {}/100, {}", tribute.name, tribute.status, tribute.health, tribute.actions().last().unwrap().name);
+                println!("{} is {}, {}/100, {}({:?})", tribute.name, tribute.status, tribute.health, tribute.actions().last().unwrap().name, tribute.actions().last().unwrap());
             }
         }
         Commands::QuickStart => {

--- a/hangry_games/src/models/tribute.rs
+++ b/hangry_games/src/models/tribute.rs
@@ -79,7 +79,7 @@ impl Tribute {
 
     pub fn take_action(&self, action: &Action) {
         use crate::models::TributeAction;
-        TributeAction::create(self.id, action.id);
+        TributeAction::create(self.id, action.id, None);
     }
 
     pub fn set_game(&mut self, game: &Game) {
@@ -174,10 +174,16 @@ impl Tribute {
 
         // Decide the next logical action
         brain.act(&mut tribute, nearby_targets.clone());
+        let mut target = None;
 
         match brain.last_action() {
             TributeAction::Move(area) => {
-                move_tribute(tribute.into(), area);
+                if let Some(area) = area {
+                    target = Some(area.as_str().to_string());
+                    move_tribute(tribute.into(), Some(area));
+                } else {
+                    move_tribute(tribute.into(), None);
+                }
             }
             TributeAction::Hide => {
                 hide_tribute(Tribute::from(tribute));
@@ -186,9 +192,9 @@ impl Tribute {
                 rest_tribute(tribute.into());
             }
             TributeAction::Attack => {
-                if let Some(target) = pick_target(self.clone(), nearby_targets.clone()) {
-                    let target = Tribute::from(target);
-                    attack_target(self.clone(), target.clone());
+                if let Some(victim) = pick_target(self.clone(), nearby_targets.clone()) {
+                    let victim = Tribute::from(victim);
+                    attack_target(self.clone(), victim.clone());
                 }
             }
             _ => {
@@ -200,7 +206,7 @@ impl Tribute {
         let last_action = crate::models::action::get_action(brain.last_action().as_str());
 
         // Connect Tribute to Action
-        tribute_action::take_action(&self.clone(), &last_action);
+        tribute_action::take_action(&self.clone(), &last_action, target);
 
         self.clone()
     }
@@ -240,10 +246,16 @@ impl Tribute {
 
         // Decide the next logical action
         brain.act(&mut tribute, nearby_targets.clone());
+        let mut target = None;
 
         match brain.last_action() {
             TributeAction::Move(area) => {
-                move_tribute(tribute.into(), area);
+                if let Some(area) = area {
+                    target = Some(area.as_str().to_string());
+                    move_tribute(tribute.into(), Some(area));
+                } else {
+                    move_tribute(tribute.into(), None);
+                }
             }
             TributeAction::Attack => {
                 // How brave does the tribute feel at night?
@@ -273,7 +285,7 @@ impl Tribute {
         let last_action = crate::models::action::get_action(brain.last_action().as_str());
 
         // Connect Tribute to Action
-        tribute_action::take_action(&self.clone(), &last_action);
+        tribute_action::take_action(&self.clone(), &last_action, target);
 
         self.clone()
     }

--- a/hangry_games/src/models/tribute.rs
+++ b/hangry_games/src/models/tribute.rs
@@ -77,6 +77,11 @@ impl Tribute {
             .expect("Error loading actions")
     }
 
+    /// Get all the TributeActions for a Tribute.
+    pub fn tribute_actions(&self) -> Vec<crate::models::TributeAction> {
+        tribute_action::TributeAction::get_all_for_tribute(self.id)
+    }
+
     pub fn take_action(&self, action: &Action) {
         use crate::models::TributeAction;
         TributeAction::create(self.id, action.id, None);
@@ -151,7 +156,7 @@ impl Tribute {
         if game.day == Some(3) {
             brain.set_preferred_action(
                 TributeAction::Move(
-                    Some(crate::areas::Area::Cornucopia)
+                    Some(crate::areas::Area::Cornucopia.to_string())
                 ),
                0.75
             );
@@ -180,7 +185,7 @@ impl Tribute {
             TributeAction::Move(area) => {
                 if area.is_some() {
                     target = Some(area.clone().unwrap().as_str().to_string());
-                    move_tribute(tribute.into(), area);
+                    move_tribute(tribute.into(), Some(area.unwrap().as_str().to_string()));
                 } else {
                     move_tribute(tribute.into(), None);
                 }
@@ -327,7 +332,7 @@ fn rest_tribute(tribute: Tribute) {
 }
 
 
-fn move_tribute(tribute: Tribute, area: Option<crate::areas::Area>) {
+fn move_tribute(tribute: Tribute, area: Option<String>) {
     let mut tribute = TributeActor::from(tribute);
     let game = get_game_by_id(tribute.game_id.unwrap()).unwrap();
     let tribute_area = tribute.clone().area.unwrap();

--- a/hangry_games/src/models/tribute.rs
+++ b/hangry_games/src/models/tribute.rs
@@ -178,9 +178,9 @@ impl Tribute {
 
         match brain.last_action() {
             TributeAction::Move(area) => {
-                if let Some(area) = area {
-                    target = Some(area.as_str().to_string());
-                    move_tribute(tribute.into(), Some(area));
+                if area.is_some() {
+                    target = Some(area.clone().unwrap().as_str().to_string());
+                    move_tribute(tribute.into(), area);
                 } else {
                     move_tribute(tribute.into(), None);
                 }
@@ -250,9 +250,9 @@ impl Tribute {
 
         match brain.last_action() {
             TributeAction::Move(area) => {
-                if let Some(area) = area {
-                    target = Some(area.as_str().to_string());
-                    move_tribute(tribute.into(), Some(area));
+                if area.is_some() {
+                    target = Some(area.clone().unwrap().as_str().to_string());
+                    move_tribute(tribute.into(), area);
                 } else {
                     move_tribute(tribute.into(), None);
                 }
@@ -332,8 +332,6 @@ fn move_tribute(tribute: Tribute, area: Option<crate::areas::Area>) {
     let game = get_game_by_id(tribute.game_id.unwrap()).unwrap();
     let tribute_area = tribute.clone().area.unwrap();
 
-    tribute.moves();
-
     let closed_areas: Vec<crate::areas::Area> = game.closed_areas.clone().unwrap_or(vec![]).iter()
         .map(|id| get_area_by_id(*id))
         .map(|a| a.unwrap())
@@ -341,6 +339,7 @@ fn move_tribute(tribute: Tribute, area: Option<crate::areas::Area>) {
         .collect();
     match &tribute.travels(closed_areas.clone(), area) {
         TravelResult::Success(area) => {
+            tribute.moves();
             tribute.changes_area(area.clone());
             println!("{} moves from {} to {}", tribute.name, tribute_area.as_str(), &area.as_str());
         }

--- a/hangry_games/src/models/tribute.rs
+++ b/hangry_games/src/models/tribute.rs
@@ -1,7 +1,7 @@
 use crate::establish_connection;
 use crate::models::{get_area, get_game_by_id, tribute_action, Action, Area, Game};
 use crate::tributes::actors::{TravelResult, Tribute as TributeActor};
-use crate::tributes::actions::{AttackOutcome, TributeAction};
+use crate::tributes::actions::{AttackOutcome, PreferredAction, TributeAction};
 use crate::schema::tribute;
 use crate::tributes::actors::pick_target;
 use diesel::prelude::*;
@@ -134,7 +134,7 @@ impl Tribute {
         let area = self.area().unwrap();
 
         // Create Tribute struct
-        let tribute = TributeActor::from(self.clone());
+        let mut tribute = TributeActor::from(self.clone());
 
         // Get game
         let game = get_game_by_id(self.game_id.unwrap()).unwrap();
@@ -142,7 +142,15 @@ impl Tribute {
         // Get Brain struct
         let mut brain = tribute.brain.clone();
         if game.day == Some(1) {
-            brain.set_preferred_action(TributeAction::Move, 0.5);
+            brain.set_preferred_action(PreferredAction::Move(None), 0.5);
+        }
+        if game.day.unwrap() % 2 == 0 {
+            brain.set_preferred_action(
+                PreferredAction::Move(
+                    Some(crate::areas::Area::Cornucopia)
+                ),
+               1.0
+            );
         }
 
         // Get nearby targets
@@ -161,7 +169,7 @@ impl Tribute {
         }
 
         // Decide the next logical action
-        brain.act(&tribute, nearby_targets.clone());
+        brain.act(&mut tribute, nearby_targets.clone());
 
         match brain.last_action() {
             TributeAction::Move => {
@@ -227,7 +235,7 @@ impl Tribute {
         let mut brain = tribute.brain.clone();
 
         // Decide the next logical action
-        brain.act(&tribute, nearby_targets.clone());
+        brain.act(&mut tribute, nearby_targets.clone());
 
         match brain.last_action() {
             TributeAction::Move => {

--- a/hangry_games/src/models/tribute.rs
+++ b/hangry_games/src/models/tribute.rs
@@ -1,7 +1,7 @@
 use crate::establish_connection;
 use crate::models::{get_area, get_game_by_id, tribute_action, Action, Area, Game};
 use crate::tributes::actors::{TravelResult, Tribute as TributeActor};
-use crate::tributes::actions::{AttackOutcome, PreferredAction, TributeAction};
+use crate::tributes::actions::{AttackOutcome, TributeAction};
 use crate::schema::tribute;
 use crate::tributes::actors::pick_target;
 use diesel::prelude::*;
@@ -142,15 +142,15 @@ impl Tribute {
         // Get Brain struct
         let mut brain = tribute.brain.clone();
         if game.day == Some(1) {
-            brain.set_preferred_action(PreferredAction::Move(None), 0.5);
+            brain.set_preferred_action(TributeAction::Move, 0.5);
         }
         if game.day.unwrap() % 2 == 0 {
-            brain.set_preferred_action(
-                PreferredAction::Move(
-                    Some(crate::areas::Area::Cornucopia)
-                ),
-               1.0
-            );
+            // brain.set_preferred_action(
+            //     TributeAction::Move(
+            //         Some(crate::areas::Area::Cornucopia)
+            //     ),
+            //    1.0
+            // );
         }
 
         // Get nearby targets

--- a/hangry_games/src/models/tribute_action.rs
+++ b/hangry_games/src/models/tribute_action.rs
@@ -35,6 +35,14 @@ impl TributeAction {
             .get_result(connection)
             .expect("Error saving new tribute action")
     }
+
+    pub fn get_all_for_tribute(tribute_id: i32) -> Vec<TributeAction> {
+        let connection = &mut establish_connection();
+        tribute_action::table
+            .filter(tribute_action::tribute_id.eq(tribute_id))
+            .load(connection)
+            .expect("Error loading tribute actions")
+    }
 }
 
 pub fn take_action(tribute: &Tribute, action: &Action, target: Option<String>) -> TributeAction {

--- a/hangry_games/src/models/tribute_action.rs
+++ b/hangry_games/src/models/tribute_action.rs
@@ -13,6 +13,7 @@ pub struct TributeAction {
     pub tribute_id: i32,
     pub action_id: i32,
     pub created_at: chrono::NaiveDateTime,
+    pub target: Option<String>,
 }
 
 #[derive(Insertable, Debug)]
@@ -20,12 +21,13 @@ pub struct TributeAction {
 pub struct NewTributeAction {
     pub tribute_id: i32,
     pub action_id: i32,
+    pub target: Option<String>,
 }
 
 impl TributeAction {
-    pub fn create(tribute_id: i32, action_id: i32) -> TributeAction {
+    pub fn create(tribute_id: i32, action_id: i32, target: Option<String>) -> TributeAction {
         let connection = &mut establish_connection();
-        let new_tribute_action = NewTributeAction { tribute_id, action_id };
+        let new_tribute_action = NewTributeAction { tribute_id, action_id, target };
 
         diesel::insert_into(tribute_action::table)
             .values(&new_tribute_action)
@@ -35,6 +37,6 @@ impl TributeAction {
     }
 }
 
-pub fn take_action(tribute: &Tribute, action: &Action) {
-    TributeAction::create(tribute.id, action.id);
+pub fn take_action(tribute: &Tribute, action: &Action, target: Option<String>) -> TributeAction {
+    TributeAction::create(tribute.id, action.id, target)
 }

--- a/hangry_games/src/schema.rs
+++ b/hangry_games/src/schema.rs
@@ -68,6 +68,7 @@ diesel::table! {
         tribute_id -> Int4,
         action_id -> Int4,
         created_at -> Timestamp,
+        target -> Nullable<Text>,
     }
 }
 

--- a/hangry_games/src/tributes/actions.rs
+++ b/hangry_games/src/tributes/actions.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use diesel::deserialize::FromSql;
+use crate::areas::Area;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum TributeAction {
@@ -72,4 +73,10 @@ pub enum AttackOutcome {
     Kill(Tribute, Tribute),
     Wound(Tribute, Tribute),
     Miss(Tribute, Tribute),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PreferredAction {
+    Move(Option<Area>),
+    UseItem,
 }

--- a/hangry_games/src/tributes/actions.rs
+++ b/hangry_games/src/tributes/actions.rs
@@ -7,7 +7,7 @@ use crate::areas::Area;
 pub enum TributeAction {
     #[default]
     None,
-    Move,
+    Move(Option<Area>),
     Rest,
     UseItem,
     Attack,
@@ -18,7 +18,7 @@ impl TributeAction {
     pub fn as_str(&self) -> &str {
         match self {
             TributeAction::None => "None",
-            TributeAction::Move => "Move",
+            TributeAction::Move(_) => "Move",
             TributeAction::Rest => "Rest",
             TributeAction::UseItem => "Use Item",
             TributeAction::Attack => "Attack",
@@ -40,7 +40,7 @@ impl FromStr for TributeAction {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "none" => Ok(TributeAction::None),
-            "move" => Ok(TributeAction::Move),
+            "move" => Ok(TributeAction::Move(None)),
             "rest" => Ok(TributeAction::Rest),
             "use item" => Ok(TributeAction::UseItem),
             "attack" => Ok(TributeAction::Attack),

--- a/hangry_games/src/tributes/actions.rs
+++ b/hangry_games/src/tributes/actions.rs
@@ -1,13 +1,15 @@
 use std::str::FromStr;
 
 use diesel::deserialize::FromSql;
-use crate::areas::Area;
+use crate::models::Action as ActionModel;
+use crate::tributes::actors::Tribute;
+
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum TributeAction {
     #[default]
     None,
-    Move(Option<Area>),
+    Move(Option<String>),
     Rest,
     UseItem,
     Attack,
@@ -49,9 +51,6 @@ impl FromStr for TributeAction {
         }
     }
 }
-
-use crate::models::Action as ActionModel;
-use crate::tributes::actors::Tribute;
 
 impl From<&ActionModel> for TributeAction {
     fn from(value: &ActionModel) -> Self {

--- a/hangry_games/src/tributes/actions.rs
+++ b/hangry_games/src/tributes/actions.rs
@@ -74,9 +74,3 @@ pub enum AttackOutcome {
     Wound(Tribute, Tribute),
     Miss(Tribute, Tribute),
 }
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum PreferredAction {
-    Move(Option<Area>),
-    UseItem,
-}

--- a/hangry_games/src/tributes/actions.rs
+++ b/hangry_games/src/tributes/actions.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use diesel::deserialize::FromSql;
+use crate::areas::Area;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum TributeAction {

--- a/hangry_games/src/tributes/actors.rs
+++ b/hangry_games/src/tributes/actors.rs
@@ -3,7 +3,7 @@ use crate::areas::Area;
 use crate::models::tribute::UpdateTribute;
 use rand::prelude::*;
 
-use super::actions::{TributeAction, AttackResult, AttackOutcome};
+use super::actions::{AttackResult, AttackOutcome};
 use super::statuses::TributeStatus;
 use super::brains::TributeBrain;
 
@@ -224,11 +224,15 @@ impl Tribute {
         }
     }
 
-    pub fn travels(&self, closed_areas: Vec<Area>) -> TravelResult {
+    pub fn travels(&self, closed_areas: Vec<Area>, suggested_area: Option<Area>) -> TravelResult {
         let mut rng = thread_rng();
         let area = self.clone().area.unwrap();
 
         if self.movement > 0 {
+            if let Some(area) = suggested_area {
+                return TravelResult::Success(area);
+            }
+
             let neighbors = area.neighbors();
             let new_area = loop {
                 let new_area = neighbors.choose(&mut rng).unwrap();

--- a/hangry_games/src/tributes/actors.rs
+++ b/hangry_games/src/tributes/actors.rs
@@ -377,7 +377,6 @@ impl From<TributeModel> for Tribute {
     }
 }
 
-use crate::models::tribute::UpdateTribute;
 impl Into<UpdateTribute> for Tribute {
     fn into(self) -> UpdateTribute {
         let area = self.area.as_ref().unwrap();

--- a/hangry_games/src/tributes/actors.rs
+++ b/hangry_games/src/tributes/actors.rs
@@ -224,12 +224,13 @@ impl Tribute {
         }
     }
 
-    pub fn travels(&self, closed_areas: Vec<Area>, suggested_area: Option<Area>) -> TravelResult {
+    pub fn travels(&self, closed_areas: Vec<Area>, suggested_area: Option<String>) -> TravelResult {
         let mut rng = thread_rng();
         let area = self.clone().area.unwrap();
 
         if self.movement > 0 {
-            if let Some(area) = suggested_area {
+            if let Some(area_string) = suggested_area {
+                let area = Area::from_str(area_string.as_str()).unwrap();
                 return TravelResult::Success(area);
             }
 

--- a/hangry_games/src/tributes/actors.rs
+++ b/hangry_games/src/tributes/actors.rs
@@ -3,7 +3,7 @@ use crate::areas::Area;
 use crate::models::tribute::UpdateTribute;
 use rand::prelude::*;
 
-use super::actions::{AttackOutcome, AttackResult};
+use super::actions::{TributeAction, AttackResult, AttackOutcome, PreferredAction};
 use super::statuses::TributeStatus;
 use super::brains::TributeBrain;
 

--- a/hangry_games/src/tributes/actors.rs
+++ b/hangry_games/src/tributes/actors.rs
@@ -3,7 +3,7 @@ use crate::areas::Area;
 use crate::models::tribute::UpdateTribute;
 use rand::prelude::*;
 
-use super::actions::{TributeAction, AttackResult, AttackOutcome, PreferredAction};
+use super::actions::{TributeAction, AttackResult, AttackOutcome};
 use super::statuses::TributeStatus;
 use super::brains::TributeBrain;
 

--- a/hangry_games/src/tributes/actors.rs
+++ b/hangry_games/src/tributes/actors.rs
@@ -103,7 +103,7 @@ impl Tribute {
 
     /// Consumes movement and removes hidden status.
     pub fn moves(&mut self) {
-        self.movement = std::cmp::max(0, self.movement - 50);
+        self.movement = std::cmp::max(0, self.movement - 25);
         self.is_hidden = Some(false);
     }
 

--- a/hangry_games/src/tributes/brains.rs
+++ b/hangry_games/src/tributes/brains.rs
@@ -33,33 +33,6 @@ impl TributeBrain {
     pub fn act(&mut self, tribute: &Tribute, nearby_tributes: Vec<Tribute>) -> TributeAction {
         if tribute.health == 0 { return TributeAction::None; }
 
-        // if let Some(preferred_action) = self.clone().preferred_action {
-        //     if thread_rng().gen_bool(self.preferred_action_percentage) {
-        //         self.previous_actions.push(preferred_action.clone());
-        //         return match preferred_action {
-        //             TributeAction::Move(area) => {
-        //                 if area.is_some() {
-        //                     if tribute.area.is_some() && &area.clone().unwrap() == tribute.area.as_ref().unwrap() {
-        //                         return TributeAction::None;
-        //                     }
-        //                     let closed_areas = vec![
-        //                         Area::Cornucopia,
-        //                         Area::Northwest,
-        //                         Area::Northeast,
-        //                         Area::Southeast,
-        //                         Area::Southwest
-        //                     ].iter().filter(|a| &a.as_str() != &area.clone().unwrap().as_str()).cloned().collect();
-        //                     tribute.travels(closed_areas);
-        //                 }
-        //                 TributeAction::None
-        //             },
-        //             _ => {
-        //                 preferred_action
-        //             }
-        //         }
-        //     }
-        // }
-
         let action = self.decide_on_action(tribute, nearby_tributes.clone());
 
         // Try to get a different action?

--- a/hangry_games/src/tributes/brains.rs
+++ b/hangry_games/src/tributes/brains.rs
@@ -33,14 +33,34 @@ impl TributeBrain {
     pub fn act(&mut self, tribute: &Tribute, nearby_tributes: Vec<Tribute>) -> TributeAction {
         if tribute.health == 0 { return TributeAction::None; }
 
-        if let Some(preferred_action) = self.clone().preferred_action {
-            if thread_rng().gen_bool(self.preferred_action_percentage) {
-                self.previous_actions.push(preferred_action.clone());
-                return preferred_action;
-            }
-        }
+        // if let Some(preferred_action) = self.clone().preferred_action {
+        //     if thread_rng().gen_bool(self.preferred_action_percentage) {
+        //         self.previous_actions.push(preferred_action.clone());
+        //         return match preferred_action {
+        //             TributeAction::Move(area) => {
+        //                 if area.is_some() {
+        //                     if tribute.area.is_some() && &area.clone().unwrap() == tribute.area.as_ref().unwrap() {
+        //                         return TributeAction::None;
+        //                     }
+        //                     let closed_areas = vec![
+        //                         Area::Cornucopia,
+        //                         Area::Northwest,
+        //                         Area::Northeast,
+        //                         Area::Southeast,
+        //                         Area::Southwest
+        //                     ].iter().filter(|a| &a.as_str() != &area.clone().unwrap().as_str()).cloned().collect();
+        //                     tribute.travels(closed_areas);
+        //                 }
+        //                 TributeAction::None
+        //             },
+        //             _ => {
+        //                 preferred_action
+        //             }
+        //         }
+        //     }
+        // }
 
-        let action = TributeBrain::decide_on_action(tribute, nearby_tributes.clone());
+        let action = self.decide_on_action(tribute, nearby_tributes.clone());
 
         // Try to get a different action?
 
@@ -58,7 +78,7 @@ impl TributeBrain {
     }
 
     /// The AI for a tribute. Automatic decisions based on current state.
-    fn decide_on_action(tribute: &Tribute, nearby_tributes: Vec<Tribute>) -> TributeAction {
+    fn decide_on_action(&mut self, tribute: &Tribute, nearby_tributes: Vec<Tribute>) -> TributeAction {
         // If the tribute isn't in the area, they do nothing
         if tribute.area.is_none() {
             return TributeAction::None;
@@ -68,6 +88,14 @@ impl TributeBrain {
         }
 
         let _area = tribute.area.as_ref().unwrap();
+
+        // If there is a preferred action, we should take it, assuming a positive roll
+        if let Some(preferred_action) = self.preferred_action.clone() {
+            if thread_rng().gen_bool(self.preferred_action_percentage) {
+                self.previous_actions.push(preferred_action.clone());
+                return preferred_action
+            }
+        }
 
         match &nearby_tributes.len() {
             0 => {
@@ -80,7 +108,7 @@ impl TributeBrain {
                         if tribute.sanity > 20 && tribute.is_visible() {
                             TributeAction::Hide
                         } else {
-                            TributeAction::Move
+                            TributeAction::Move(None)
                         }
                     },
                     // health is good, move
@@ -88,7 +116,7 @@ impl TributeBrain {
                         // If the tribute has movement, move
                         match tribute.movement {
                             0 => TributeAction::Rest,
-                            _ => TributeAction::Move,
+                            _ => TributeAction::Move(None),
                         }
                     }
                 }
@@ -107,7 +135,7 @@ impl TributeBrain {
                     // health isn't great, run away
                     6..=10 => {
                         if tribute.sanity > 20 {
-                            TributeAction::Move
+                            TributeAction::Move(None)
                         } else {
                             TributeAction::Attack
                         }
@@ -125,7 +153,7 @@ impl TributeBrain {
                     // Smart enough to know better, hides
                     85..101 => TributeAction::Hide,
                     // Average intelligence, moves
-                    _ => TributeAction::Move,
+                    _ => TributeAction::Move(None),
                 }
             }
         }
@@ -141,7 +169,7 @@ mod tests {
         // If there are no enemies nearby, the tribute should move
         let mut tribute = Tribute::new("Katniss".to_string(), None);
         let action = tribute.brain.act(&tribute.clone(), vec![]);
-        assert_eq!(action, TributeAction::Move);
+        assert_eq!(action, TributeAction::Move(None));
     }
 
     #[test]
@@ -180,6 +208,6 @@ mod tests {
         tribute.takes_physical_damage(90);
         let tribute2 = Tribute::new("Peeta".to_string(), None);
         let action = tribute.brain.act(&tribute.clone(),vec![tribute.clone(), tribute2]);
-        assert_eq!(action, TributeAction::Move);
+        assert_eq!(action, TributeAction::Move(None));
     }
 }


### PR DESCRIPTION
Adds the ability to suggest a tribute move to a certain area.

Suggestions always come with a probability variable to show how firm of a suggestion it is.